### PR TITLE
Bug repro: prefer `type: "module"`

### DIFF
--- a/examples/node_modules/package-json-redirects/cjs/package.json
+++ b/examples/node_modules/package-json-redirects/cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/examples/node_modules/package-json-redirects/esm/package.json
+++ b/examples/node_modules/package-json-redirects/esm/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}

--- a/examples/node_modules/package-json-redirects/package.json
+++ b/examples/node_modules/package-json-redirects/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "cjs/index.js",
   "types": "types/index.d.ts",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./types/index.d.ts",


### PR DESCRIPTION
I'd guessed that setting "type" to "main" at the top level but to "commonjs" at a lower one would work just as well as the setup in this project example, but it doesn't seem to. Is this a bug?