### PR TITLE
Demonstrate wildcard fallback for package-json-redirects

### DIFF
--- a/examples/node11-resolution/main.ts
+++ b/examples/node11-resolution/main.ts
@@ -9,9 +9,14 @@ assert(extensionlessTwo === "extensionless/two/index.js");
 import { index as pjr } from "package-json-redirects";
 import { one as pjrOne } from "package-json-redirects/one";
 import { two as pjrTwo } from "package-json-redirects/two";
+import { one as pjrWcOne } from "package-json-redirects/three/one.js";
+import { two as pjrWcTwo } from "package-json-redirects/three/two.js";
+
 assert(pjr === "package-json-redirects/cjs/index.js");
 assert(pjrOne === "package-json-redirects/cjs/one.js");
 assert(pjrTwo === "package-json-redirects/cjs/two.js");
+assert(pjrWcOne === "package-json-redirects/cjs/one.js");
+assert(pjrWcTwo === "package-json-redirects/cjs/two.js");
 
 // These fail in Node 11 because only TypeScript follows `typesVersions`
 import tvw from "types-versions-wildcards";

--- a/examples/node16-resolution/main.cts
+++ b/examples/node16-resolution/main.cts
@@ -9,9 +9,13 @@ assert(extensionlessTwo === "extensionless/two/index.js");
 import { index as pjr } from "package-json-redirects";
 import { one as pjrOne } from "package-json-redirects/one";
 import { two as pjrTwo } from "package-json-redirects/two";
+import { one as pjrWcOne } from "package-json-redirects/three/one.js";
+import { two as pjrWcTwo } from "package-json-redirects/three/two.js";
 assert(pjr === "package-json-redirects/cjs/index.js");
 assert(pjrOne === "package-json-redirects/cjs/one.js");
 assert(pjrTwo === "package-json-redirects/cjs/two.js");
+assert(pjrWcOne === "package-json-redirects/cjs/one.js");
+assert(pjrWcTwo === "package-json-redirects/cjs/two.js");
 
 import tvw from "types-versions-wildcards";
 import tvwOne from "types-versions-wildcards/one";

--- a/examples/node16-resolution/main.mts
+++ b/examples/node16-resolution/main.mts
@@ -9,9 +9,13 @@ assert(extensionlessTwo === "extensionless/two/index.mjs");
 import { index as pjr } from "package-json-redirects";
 import { one as pjrOne } from "package-json-redirects/one";
 import { two as pjrTwo } from "package-json-redirects/two";
+import { one as pjrWcOne } from "package-json-redirects/three/one.js";
+import { two as pjrWcTwo } from "package-json-redirects/three/two.js";
 assert(pjr === "package-json-redirects/esm/index.js");
 assert(pjrOne === "package-json-redirects/esm/one.js");
 assert(pjrTwo === "package-json-redirects/esm/two.js");
+assert(pjrWcOne === "package-json-redirects/esm/one.js");
+assert(pjrWcTwo === "package-json-redirects/esm/two.js");
 
 import tvw from "types-versions-wildcards";
 import tvwOne from "types-versions-wildcards/one";

--- a/examples/node_modules/package-json-redirects/README.md
+++ b/examples/node_modules/package-json-redirects/README.md
@@ -33,4 +33,4 @@ Cons:
 
 - Lots of files and folders (aesthetic)
 - Need to add more every time a new subpath is added
-- Cannot support `*` wildcards
+- Need to create a `package.json` for all possible wildcard `*` matches 

--- a/examples/node_modules/package-json-redirects/README.md
+++ b/examples/node_modules/package-json-redirects/README.md
@@ -33,4 +33,4 @@ Cons:
 
 - Lots of files and folders (aesthetic)
 - Need to add more every time a new subpath is added
-- Need to create a `package.json` for all possible wildcard `*` matches 
+- Cannot support `*` wildcards; need to create a `package.json` for all possible matches

--- a/examples/node_modules/package-json-redirects/package.json
+++ b/examples/node_modules/package-json-redirects/package.json
@@ -18,6 +18,11 @@
       "types": "./types/two.d.ts",
       "import": "./esm/two.js",
       "default": "./cjs/two.js"
+    },
+    "./three/*.js": {
+      "types": "./types/*.d.ts",
+      "import": "./esm/*.js",
+      "default": "./cjs/*.js"
     }
   }
 }

--- a/examples/node_modules/package-json-redirects/three/one.js/package.json
+++ b/examples/node_modules/package-json-redirects/three/one.js/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../../cjs/one.js",
+  "types": "../../types/one.d.ts"
+}

--- a/examples/node_modules/package-json-redirects/three/package.json
+++ b/examples/node_modules/package-json-redirects/three/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../cjs/index.js",
+  "types": "../types/one.d.ts"
+}

--- a/examples/node_modules/package-json-redirects/three/two.js/package.json
+++ b/examples/node_modules/package-json-redirects/three/two.js/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../../cjs/two.js",
+  "types": "../../types/two.d.ts"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "example-exports-typescript-resolution-compat",
+  "name": "example-subpath-exports-ts-compat",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "example-exports-typescript-resolution-compat",
+      "name": "example-subpath-exports-ts-compat",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
It seems the package.json mirroring strategy can also provide wildcard fallback, providing a package.json is created for all possible wildcard matches. Of course this is unaesthetic and cumbersome, but thought it might be worth documenting for anyone coming at this from the perspective of generating fallbacks.

Thanks btw for putting this repo together. Super helpful.